### PR TITLE
stuff

### DIFF
--- a/common/src/main/java/gg/moonflower/pollen/api/block/FollowBlock.java
+++ b/common/src/main/java/gg/moonflower/pollen/api/block/FollowBlock.java
@@ -1,0 +1,28 @@
+package gg.moonflower.pollen.api.block;
+
+import gg.moonflower.pollen.api.util.GroupUtil;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+
+/**
+ * A modified block with the ability to "follow" any item in the creative menu instead of appearing at the bottom.
+ *
+ * @author Eltrutlikes
+ * @author ebo2022
+ */
+public class FollowBlock extends Block {
+    private final Item followItem;
+
+    public FollowBlock(Properties properties, Item followItem) {
+        super(properties);
+        this.followItem = followItem;
+    }
+
+    @Override
+    public void fillItemCategory(CreativeModeTab group, NonNullList<ItemStack> items) {
+        GroupUtil.fillItem(this.asItem(), followItem, group, items);
+    }
+}

--- a/common/src/main/java/gg/moonflower/pollen/api/item/FollowItem.java
+++ b/common/src/main/java/gg/moonflower/pollen/api/item/FollowItem.java
@@ -1,0 +1,27 @@
+package gg.moonflower.pollen.api.item;
+
+import gg.moonflower.pollen.api.util.GroupUtil;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * A modified item with the ability to "follow" any item in the creative menu instead of appearing at the bottom.
+ *
+ * @author Eltrutlikes
+ * @author ebo2022
+ */
+public class FollowItem extends Item {
+    private final Item followItem;
+
+    public FollowItem(Properties properties, Item followItem) {
+        super(properties);
+        this.followItem = followItem;
+    }
+
+    @Override
+    public void fillItemCategory(CreativeModeTab group, NonNullList<ItemStack> items) {
+        GroupUtil.fillItem(this.asItem(), this.followItem, group, items);
+    }
+}

--- a/common/src/main/java/gg/moonflower/pollen/api/platform/Platform.java
+++ b/common/src/main/java/gg/moonflower/pollen/api/platform/Platform.java
@@ -97,6 +97,32 @@ public abstract class Platform {
     }
 
     /**
+     * Checks to see if the specified mods are loaded.
+     *
+     * @param forced Whether all mods in the list need to be loaded to return true
+     * @param modIds A list of mod ids to check
+     * @return Whether any (all if "forced" is set to true) of the specified mod ids are loaded
+     */
+    public static boolean areModsLoaded(boolean forced, String ...modIds) {
+        if (modIds == null) return true;
+        if (forced) {
+            for (String mod : modIds) {
+                if (isModLoaded(mod)) {
+                    return true;
+                }
+            }
+            return false;
+        } else {
+            for (String mod : modIds) {
+                if (!isModLoaded(mod)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    /**
      * @return A stream of all loaded mods
      */
     @ExpectPlatform

--- a/common/src/main/java/gg/moonflower/pollen/api/registry/CompostableRegistry.java
+++ b/common/src/main/java/gg/moonflower/pollen/api/registry/CompostableRegistry.java
@@ -1,0 +1,34 @@
+package gg.moonflower.pollen.api.registry;
+
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.ComposterBlock;
+
+
+/**
+ * A simple registry to add Composter behavior to items.
+ *
+ * @author Eltrutlikes
+ * @author ebo2022
+ */
+public class CompostableRegistry {
+
+    /**
+     * Registers composting behavior for the specified item.
+     *
+     * @param item              The item to register compost behavior for
+     * @param compostableChance The chance (as a {@link Float}) that the item will fill a composter
+     */
+    public static void register(ItemLike item, float compostableChance) {
+        ComposterBlock.add(compostableChance, item);
+    }
+
+    /**
+     * Defaulted chances for compostable blocks and items.
+     */
+    public static class CompostableChance {
+        public static final float SEEDS = 0.3F;
+        public static final float PLANTS = 0.65F;
+        public static final float BAKED_GOODS = 0.85F;
+        public static final float PIES = 1.0F;
+    }
+}

--- a/common/src/main/java/gg/moonflower/pollen/api/registry/DispenserBehaviorRegistry.java
+++ b/common/src/main/java/gg/moonflower/pollen/api/registry/DispenserBehaviorRegistry.java
@@ -1,0 +1,46 @@
+package gg.moonflower.pollen.api.registry;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.dispenser.DispenseItemBehavior;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.DispenserBlock;
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * A registry to set how Dispensers and Droppers interact with blocks and items.
+ *
+ * @author Eltrutlikes
+ * @author ebo2022
+ */
+public class DispenserBehaviorRegistry {
+
+    /**
+     * Registers basic behavior for the specified block and item.
+     *
+     * @param item        The item to register behavior for
+     * @param block       The block the item will interact with
+     * @param newBehavior The new dispenser behavior to register
+     */
+    public static void registerSimpleBehavior(ItemLike item, Block block, DispenseItemBehavior newBehavior) {
+        DispenseItemBehavior oldBehavior = DispenserBlock.DISPENSER_REGISTRY.get(item);
+        DispenserBlock.registerBehavior(item, (source, stack) -> {
+            Direction dir = source.getBlockState().getValue(DispenserBlock.FACING);
+            BlockPos pos = source.getPos().relative(dir);
+            BlockState state = source.getLevel().getBlockState(pos);
+
+            return state.is(block) ? newBehavior.dispense(source, stack) : oldBehavior.dispense(source, stack);
+        });
+    }
+
+    /**
+     * Registers behavior for the specified item.
+     *
+     * @param item     The item to register behavior for
+     * @param behavior The dispenser behavior to register
+     */
+    public static void registerBehavior(ItemLike item, DispenseItemBehavior behavior) {
+        DispenserBlock.registerBehavior(item, behavior);
+    }
+}

--- a/common/src/main/java/gg/moonflower/pollen/api/registry/FlammableRegistry.java
+++ b/common/src/main/java/gg/moonflower/pollen/api/registry/FlammableRegistry.java
@@ -1,0 +1,40 @@
+package gg.moonflower.pollen.api.registry;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.FireBlock;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * A simple registry to set how blocks interact with Fire.
+ *
+ * @author Eltrutlikes
+ * @author ebo2022
+ */
+public class FlammableRegistry {
+
+    /**
+     * Registers flammability behavior for the specified block.
+     *
+     * @param block         The block to register flammability behavior for
+     * @param encouragement How quickly the block will catch fire
+     * @param flammability  How quickly the block burns away when on fire
+     */
+    public static void register(Block block, int encouragement, int flammability) {
+        FireBlock fireBlock = (FireBlock) Blocks.FIRE;
+        fireBlock.setFlammable(block, encouragement, flammability);
+    }
+
+    /**
+     * Defaulted values for flammable blocks.
+     */
+    public static class FlammableChance {
+        public static final Pair<Integer, Integer> WOOD = Pair.of(5, 5);
+        public static final Pair<Integer, Integer> PLANKS = Pair.of(5, 20);
+        public static final Pair<Integer, Integer> BOOKSHELF = Pair.of(30, 20);
+        public static final Pair<Integer, Integer> LEAVES = Pair.of(30, 60);
+        public static final Pair<Integer, Integer> WOOL = Pair.of(30, 60);
+        public static final Pair<Integer, Integer> CARPET = Pair.of(60, 20);
+        public static final Pair<Integer, Integer> FLOWER = Pair.of(60, 100);
+    }
+}

--- a/common/src/main/java/gg/moonflower/pollen/api/util/GroupUtil.java
+++ b/common/src/main/java/gg/moonflower/pollen/api/util/GroupUtil.java
@@ -1,0 +1,33 @@
+package gg.moonflower.pollen.api.util;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+
+/**
+ * Ease-of-access methods for indexing the creative menu.
+ *
+ * @author Eltrutlikes
+ * @author ebo2022
+ */
+public class GroupUtil {
+    public static int getIndex(Item item, NonNullList<ItemStack> items) {
+        for (int i = 0; i < items.size(); i++) {
+            if (items.get(i).getItem() == item) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static void fillItem(Item item, Item followItem, CreativeModeTab group, NonNullList<ItemStack> items) {
+        int index = getIndex(followItem, items);
+        if (index != -1) {
+            items.add(++index, new ItemStack(item));
+        } else {
+            items.add(new ItemStack(item));
+        }
+    }
+}

--- a/common/src/main/resources/pollen.accesswidener
+++ b/common/src/main/resources/pollen.accesswidener
@@ -26,3 +26,8 @@ transitive-accessible method net/minecraft/world/entity/Entity getSwimHighSpeedS
 transitive-accessible method net/minecraft/world/entity/ai/memory/MemoryModuleType <init> (Ljava/util/Optional;)V
 transitive-accessible method net/minecraft/world/entity/ai/sensing/SensorType <init> (Ljava/util/function/Supplier;)V
 transitive-accessible method net/minecraft/world/entity/schedule/Activity <init> (Ljava/lang/String;)V
+
+accessible method net/minecraft/world/level/block/FireBlock setFlammable (Lnet/minecraft/world/level/block/Block;II)V
+accessible method net/minecraft/world/level/block/ComposterBlock add (FLnet/minecraft/world/level/ItemLike;)V
+
+accessible field net/minecraft/world/level/block/DispenserBlock DISPENSER_REGISTRY Ljava/util/Map;


### PR DESCRIPTION
This PR contains a few things me and a few other people at Team Aurora have found useful and would like to merge directly into Pollen for ease-of-access.

Here's the brief list:

- Modified "FollowBlock" and "FollowItem" classes that are able to "follow" a specified item in the creative inventory
- A new platform method ("areModsLoaded", including a toggle for whether all need to be present to return true
- A compostable registry so nobody has to dig into internals in the vanilla ComposterBlock
- A Flammable Registry, same as previous but applied to fire behavior
- GroupUtil class, used in FollowItem and FollowBlock for indexing the creative menu