### PR TITLE
1.19.2 build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,17 @@ allprojects {
         maven { url "https://repo.moonflower.gg/releases"}
         maven { url "https://maven.parchmentmc.org"}
         maven { url "https://jitpack.io" }
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name = "Modrinth"
+                    url = "https://api.modrinth.com/maven"
+                }
+            }
+            filter {
+                includeGroup "maven.modrinth"
+            }
+        }
         maven {
             url "https://www.cursemaven.com"
             content {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     include "dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cardinal_components_version}"
     // Needed for making sure render changes apply
     modCompileOnly "maven.modrinth:sodium:mc1.19.2-0.4.4"
-    modCompileOnly "maven.modrinth:iris:1.6.4+1.19.2"
+    modCompileOnly "maven.modrinth:iris:${rootProject.iris_version}+1.19.2"
 
     modRuntimeOnly "me.djtheredstoner:DevAuth-fabric:${rootProject.devauth_version}"
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -83,8 +83,8 @@ dependencies {
     include "dev.onyxstudios.cardinal-components-api:cardinal-components-base:${project.cardinal_components_version}"
     include "dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cardinal_components_version}"
     // Needed for making sure render changes apply
-    modCompileOnly "curse.maven:sodium-394468:3605309"
-    modCompileOnly "curse.maven:irisshaders-455508:${project.iris_version}"
+    modCompileOnly "maven.modrinth:sodium:mc1.19.2-0.4.4"
+    modCompileOnly "maven.modrinth:iris:1.6.4+1.19.2"
 
     modRuntimeOnly "me.djtheredstoner:DevAuth-fabric:${rootProject.devauth_version}"
 

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -44,7 +44,7 @@
   "depends": {
     "fabricloader": ">=0.12",
     "fabric": ">=0.47",
-    "minecraft": "1.18.x >=1.18.2"
+    "minecraft": "1.19.2"
   },
   "conflicts": {
     "grindenchantments": "<1.6.2"

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -72,8 +72,8 @@ dependencies {
     modRuntimeOnly "curse.maven:configured-457570:3559398"
     modRuntimeOnly "curse.maven:catalogue-459701:3559402"
 
-    modCompileOnly "mezz.jei:jei-${rootProject.minecraft_version}:${rootProject.jei_version}:api"
-    modRuntimeOnly "mezz.jei:jei-${rootProject.minecraft_version}:${rootProject.jei_version}"
+    modCompileOnly "mezz.jei:jei-${rootProject.minecraft_version}-forge-api:${rootProject.jei_version}"
+    modRuntimeOnly "mezz.jei:jei-${rootProject.minecraft_version}-forge:${rootProject.jei_version}"
 
     forgeRuntimeLibrary "com.github.LlamaLad7:MixinExtras:${rootProject.mixin_extras_version}"
     annotationProcessor "com.github.LlamaLad7:MixinExtras:${rootProject.mixin_extras_version}"

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -26,6 +26,6 @@ side = "BOTH"
 [[dependencies.${id}]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.18.2,)"
+versionRange = "[1.19.2]"
 ordering = "NONE"
 side = "BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,20 +6,20 @@ mod_version=1.6.1
 maven_group=gg.moonflower
 
 # Dependencies
-minecraft_version=1.18.2
-parchment_version=2022.05.01
+minecraft_version=1.19.2
+parchment_version=2022.08.14
 molang_compiler_version=75864d6
 cardinal_components_version=4.1.4
 night_config_version=3.6.4
-jei_version=9.5.5.174
-iris_version=3820231
+jei_version=11.5.2.1000
+iris_version=1.6.4
 devauth_version=1.1.0
 mixin_extras_version=0.1.0-rc5
 
 # Forge
-forge_version=40.1.0
+forge_version=43.1.0
 
 # Fabric
-fabric_loader_version=0.13.3
-fabric_api_version=0.58.0+1.18.2
-mod_menu_version=3.2.1
+fabric_loader_version=0.14.21
+fabric_api_version=0.76.0+1.19.2
+mod_menu_version=3.2.3


### PR DESCRIPTION
_Reopened with fixed changes as I'll continue to work on 1.19.2 branch_

I apologize very much for a practically empty pull request, but I know that many aspiring developers have problems with setting up build systems, so I feel like it's important to keep the 1.19.2 branch easy to clone and get running. This one just sets proper dependencies for the 1.19.2 branch, moving Sodium and Iris to Modrinth Maven repo, updating JEI paths, etc.

I hope to jump on this with as much time as I can give, as I practically got Etched working, and I would be happy to see it on 1.19.2. I will create a meaningful PR for Etched 1.19.2 soon.
